### PR TITLE
Improve label of "view shortcuts" action

### DIFF
--- a/data/resources/ui/shortcuts.ui
+++ b/data/resources/ui/shortcuts.ui
@@ -34,7 +34,7 @@
             <child>
               <object class="GtkShortcutsShortcut" id ="app-shortcuts">
                 <property name="visible">1</property>
-                <property name="title" translatable="yes" context="shortcut window">View configured shortcuts</property>
+                <property name="title" translatable="yes" context="shortcut window">Show keyboard shortcuts</property>
               </object>
             </child>
           </object>

--- a/po/tilix.pot
+++ b/po/tilix.pot
@@ -2235,7 +2235,7 @@ msgstr ""
 
 #: data/resources/ui/shortcuts.ui:37
 msgctxt "shortcut window"
-msgid "View configured shortcuts"
+msgid "Show keyboard shortcuts"
 msgstr ""
 
 #: data/resources/ui/shortcuts.ui:45


### PR DESCRIPTION
The previous label ("View configured shortcuts") implied that what would be shown was only the shortcuts that were explicitly configured (by the user), but this is not the case.

The new label ("Show keyboard shortcuts") removes the ambiguity, uses a verb whose actor is the program (in line with the other actions) and explicitly mentions the term keyboard shortcuts, for extra clarity.
